### PR TITLE
Use C compiler from the environment if it is set

### DIFF
--- a/makefile
+++ b/makefile
@@ -100,7 +100,7 @@
 ################
 ## CHANGE NAME OF ANSI COMPILER HERE
 ################
-CC      = gcc
+CC      ?= gcc
 # Current values for DATABASE are: INFORMIX, DB2, TDAT (Teradata)
 #                                  SQLSERVER, SYBASE, ORACLE
 # Current values for MACHINE are:  ATT, DOS, HP, IBM, ICL, MVS, 


### PR DESCRIPTION
When the environment variable `CC` is set, it is a good practice to use it as a compiler.